### PR TITLE
Rearrange how-to and trust sections

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -63,12 +63,17 @@
     .section{padding:40px 0;border-top:1px solid var(--line)}
     .section h2{font-size:1.8rem;margin:0 0 .6rem}
     .steps{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}
+    .steps.steps--compact{grid-template-columns:1fr}
     .step{background:#fff;border:1px solid var(--line);padding:14px;border-radius:var(--radius)}
     .pricing{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
     table{width:100%;border-collapse:collapse;background:#fff;border:1px solid var(--line);border-radius:var(--radius);overflow:hidden}
     th,td{padding:.7rem .8rem;border-bottom:1px solid var(--line);text-align:left}
     tr:last-child td{border-bottom:none}
     .contact{display:grid;grid-template-columns:1.2fr .8fr;gap:16px}
+    .trust{display:grid;grid-template-columns:1fr 1.35fr;gap:16px;align-items:start}
+    .trust__reasons{display:flex;flex-direction:column;gap:.6rem}
+    .trust__reasons h2{margin:0}
+    .trust__reasons ul{margin:0;padding-left:18px;color:#1f2937}
     .box{border:1px solid var(--line);border-radius:var(--radius);padding:14px;background:#fff}
     .contact .box h3{margin:.2rem 0 .6rem}
     .field{display:flex;flex-direction:column;gap:.3rem;margin:.5rem 0}
@@ -79,14 +84,15 @@
     .flash--success{border:1px solid #86efac;background:#f0fdf4;color:#14532d}
     .flash--error{border:1px solid #fca5a5;background:#fee2e2;color:#991b1b}
     .stack{display:grid;gap:.6rem}
-    .testimonials{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}
+    .testimonials{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+    .testimonials .box{height:100%}
     .faq{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
     details{border:1px solid var(--line);border-radius:12px;padding:.7rem 1rem;background:#fff}
     summary{cursor:pointer;font-weight:700}
     .footer{padding:28px 0;border-top:1px solid var(--line);font-size:.95rem;color:#334155}
     .skip{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
     .skip:focus{position:static;width:auto;height:auto;padding:.5rem;background:#fff;border:2px solid var(--primary);z-index:1000}
-    @media (max-width:900px){.steps{grid-template-columns:1fr 1fr}.pricing{grid-template-columns:1fr}.contact{grid-template-columns:1fr}.testimonials{grid-template-columns:1fr 1fr}.faq{grid-template-columns:1fr}}
+    @media (max-width:900px){.steps{grid-template-columns:1fr 1fr}.pricing{grid-template-columns:1fr}.contact{grid-template-columns:1fr}.trust{grid-template-columns:1fr}.testimonials{grid-template-columns:1fr 1fr}.faq{grid-template-columns:1fr}}
     @media (max-width:600px){.badges{grid-template-columns:1fr}.steps{grid-template-columns:1fr}.testimonials{grid-template-columns:1fr}}
   </style>
 </head>
@@ -211,14 +217,33 @@
       </div>
     </section>
 
-    <section id="how" class="section" aria-labelledby="how-title">
+    <section id="trust" class="section" aria-labelledby="trust-title">
       <div class="container">
-        <h2 id="how-title">Как это работает</h2>
-        <div class="steps">
-          <div class="step"><strong>1) Выбираете инструмент</strong><br><span class="meta">На этой странице — по названию и тегам</span></div>
-          <div class="step"><strong>2) Пишите нам</strong><br><span class="meta">Телефон или Telegram — отвечаем быстро</span></div>
-          <div class="step"><strong>3) Забираете или ждёте доставку</strong><br><span class="meta">В удобное время</span></div>
-          <div class="step"><strong>4) Возврат и залог</strong><br><span class="meta">Возвращаете инструмент — возвращаем залог</span></div>
+        <div class="trust">
+          <div class="trust__reasons">
+            <h2 id="trust-title">Почему нам доверяют</h2>
+            <ul class="stack">
+              <li>Фото и видео инструмента перед выдачей</li>
+              <li>Паспортные данные и простой договор</li>
+              <li>Честный залог и своевременный возврат</li>
+            </ul>
+          </div>
+          <div class="stack">
+            <h3>Отзывы</h3>
+            <div class="testimonials" aria-live="polite">
+              {% for review in reviews %}
+                <blockquote class="box" style="display:flex;gap:.6rem;align-items:flex-start">
+                  <span aria-hidden="true">{{ platform_icons.get(review.platform, '')|safe }}</span>
+                  <span>
+                    <span style="display:block">{{ review.text }}</span>
+                    <span class="meta">— {{ review.author or 'Пользователь' }}, {{ review.date or '' }} · <a href="{{ review.url }}" target="_blank" rel="noopener">Источник</a></span>
+                  </span>
+                </blockquote>
+              {% else %}
+                <p class="meta">Отзывы появятся совсем скоро.</p>
+              {% endfor %}
+            </div>
+          </div>
         </div>
       </div>
     </section>
@@ -266,28 +291,13 @@
             </form>
           </div>
         </div>
-        <aside class="box">
-          <h3>Почему нам доверяют</h3>
-          <ul class="stack" style="margin:0;padding-left:18px">
-            <li>Фото и видео инструмента перед выдачей</li>
-            <li>Паспортные данные и простой договор</li>
-            <li>Честный залог и своевременный возврат</li>
-          </ul>
-          <div class="section" style="padding-top:12px;border:0">
-            <h3>Отзывы</h3>
-            <div class="testimonials" aria-live="polite">
-              {% for review in reviews %}
-                <blockquote class="box" style="display:flex;gap:.6rem;align-items:flex-start">
-                  <span aria-hidden="true">{{ platform_icons.get(review.platform, '')|safe }}</span>
-                  <span>
-                    <span style="display:block">{{ review.text }}</span>
-                    <span class="meta">— {{ review.author or 'Пользователь' }}, {{ review.date or '' }} · <a href="{{ review.url }}" target="_blank" rel="noopener">Источник</a></span>
-                  </span>
-                </blockquote>
-              {% else %}
-                <p class="meta">Отзывы появятся совсем скоро.</p>
-              {% endfor %}
-            </div>
+        <aside class="box" id="how" aria-labelledby="how-title">
+          <h3 id="how-title">Как это работает</h3>
+          <div class="steps steps--compact">
+            <div class="step"><strong>1) Выбираете инструмент</strong><br><span class="meta">На этой странице — по названию и тегам</span></div>
+            <div class="step"><strong>2) Пишите нам</strong><br><span class="meta">Телефон или Telegram — отвечаем быстро</span></div>
+            <div class="step"><strong>3) Забираете или ждёте доставку</strong><br><span class="meta">В удобное время</span></div>
+            <div class="step"><strong>4) Возврат и залог</strong><br><span class="meta">Возвращаете инструмент — возвращаем залог</span></div>
           </div>
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- move the trust reasons and testimonials into a dedicated section that replaces the old "Как это работает" block
- relocate the "Как это работает" steps into the booking sidebar and add layout styles to keep the grid tidy on smaller screens
- flatten the "Почему нам доверяют" panel and widen the testimonials cards for a broader appearance

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cc647af99883208d1777b6dc7f728e